### PR TITLE
🧵 Add threaded replies to thoughts (web, API, CLI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,15 @@ Visit `http://localhost:3000/admin` to access the admin interface.
 #### Public Endpoints (no auth required)
 
 ```bash
-# List all thoughts
+# List all top-level thoughts (excludes replies)
 GET /api/thoughts
 GET /api/thoughts?tag=rails&page=1&per_page=20
 
-# Get single thought
+# Get single thought with replies
 GET /api/thoughts/:id
+
+# Get complete thread (root thought with all nested replies)
+GET /api/thoughts/:id/thread
 
 # Get all tags
 GET /api/tags
@@ -90,7 +93,7 @@ GET /api/tags
 #### Authenticated Endpoints (Bearer token required)
 
 ```bash
-# Create thought
+# Create thought (optionally as a reply)
 POST /api/thoughts
 Authorization: Bearer YOUR_API_TOKEN
 Content-Type: application/json
@@ -98,7 +101,29 @@ Content-Type: application/json
 {
   "thought": {
     "content": "Hello world!",
-    "tags": ["greeting"]
+    "tags": ["greeting"],
+    "parent_id": "abc123XYZ456"  # Optional: public_id of parent thought
+  }
+}
+
+# Response (201 Created)
+{
+  "thought": {
+    "id": "xyz789ABC123",
+    "content": "Hello world!",
+    "tags": ["greeting"],
+    "source": "web",
+    "created_at": "2024-01-15T10:30:00Z",
+    "parent_id": null,              # null if top-level, parent's public_id if reply
+    "reply_count": 0,
+    "replies": []                   # Only populated on GET /api/thoughts/:id
+  }
+}
+
+# Error: unknown parent (422 Unprocessable Content)
+{
+  "errors": {
+    "parent_id": ["does not exist"]
   }
 }
 
@@ -110,6 +135,17 @@ Authorization: Bearer YOUR_API_TOKEN
 DELETE /api/thoughts/:id
 Authorization: Bearer YOUR_API_TOKEN
 ```
+
+#### Response Fields
+
+- `id`: Public ID of the thought (used in URLs)
+- `content`: 140-character thought text
+- `tags`: Array of tags
+- `source`: Origin of post (`web`, `cli`, or `iphone`)
+- `created_at`: ISO 8601 timestamp
+- `parent_id`: Public ID of parent thought (null for top-level thoughts)
+- `reply_count`: Number of direct replies
+- `replies`: Nested array of reply thoughts (only included on `GET /api/thoughts/:id` and `GET /api/thoughts/:id/thread`, oldest first)
 
 ### Command Line Interface
 
@@ -144,8 +180,13 @@ thought "Hello world"
 thought -t coding "Working on a new feature"
 thought -t work,meeting "Standup done"
 
+# Reply to a thought (use parent's public_id)
+thought -r abc123XYZ456 "Replying to that"
+thought --reply=abc123XYZ456 -t coding "Tagged reply"
+
 # Pipe input
 echo "Quick note" | thought -t idea
+echo "Piped reply" | thought -r abc123XYZ456
 ```
 
 #### Commands
@@ -154,9 +195,25 @@ echo "Quick note" | thought -t idea
 |---------|-------------|
 | `thought "content"` | Post a thought |
 | `thought -t tag "content"` | Post with tags |
+| `thought -r id "content"` | Post as reply to a thought |
 | `thought --init` | Setup configuration |
 | `thought --config` | Show current config |
 | `thought --help` | Show help |
+
+#### Threaded Replies
+
+Use the `-r` or `--reply` flag to respond to an existing thought:
+
+```bash
+# Reply to a thought
+thought -r abc123XYZ456 "Great point!"
+
+# Chain replies using the returned ID
+thought -r abc123XYZ456 "First reply"
+thought -r xyz789ABC123 "Reply to the reply"
+```
+
+The CLI will display the parent's public_id when posting a reply, allowing you to chain further replies from the terminal.
 
 See [doc/cli.md](doc/cli.md) for full documentation.
 

--- a/app/controllers/admin/thoughts_controller.rb
+++ b/app/controllers/admin/thoughts_controller.rb
@@ -12,7 +12,12 @@ module Admin
     end
 
     def new
-      @thought = Thought.new
+      if params[:parent_id].present?
+        @parent = Thought.find_by(public_id: params[:parent_id])
+        @thought = Thought.new(parent: @parent)
+      else
+        @thought = Thought.new
+      end
     end
 
     def create
@@ -48,7 +53,7 @@ module Admin
     end
 
     def thought_params
-      params.require(:thought).permit(:content, :created_at, tags: [])
+      params.require(:thought).permit(:content, :created_at, :parent_id, tags: [])
     end
   end
 end

--- a/app/controllers/api/thoughts_controller.rb
+++ b/app/controllers/api/thoughts_controller.rb
@@ -2,11 +2,11 @@ module Api
   class ThoughtsController < BaseController
     include SourceDetectable
 
-    before_action :set_thought, only: [ :show, :update, :destroy ]
+    before_action :set_thought, only: [ :show, :update, :destroy, :thread ]
 
     # GET /api/thoughts
     def index
-      @thoughts = Thought.recent.page(params[:page]).per(params[:per_page] || 20)
+      @thoughts = Thought.top_level.recent.page(params[:page]).per(params[:per_page] || 20)
 
       if params[:tag].present?
         @thoughts = @thoughts.with_tag(params[:tag])
@@ -30,13 +30,31 @@ module Api
       # Increment view count for public (unauthenticated) requests
       @thought.increment_view_count! unless authenticated?
 
-      render json: { thought: thought_json(@thought) }
+      render json: { thought: thought_json(@thought, include_replies: true) }
+    end
+
+    # GET /api/thoughts/:id/thread
+    def thread
+      root = @thought.thread_root
+
+      render json: { thought: thought_json(root, include_replies: true) }
     end
 
     # POST /api/thoughts
     def create
       @thought = Thought.new(thought_params)
       @thought.source = detect_source
+
+      if params[:thought][:parent_id].present?
+        parent = Thought.find_by(public_id: params[:thought][:parent_id])
+
+        if parent.nil?
+          render json: { errors: { parent_id: [ "does not exist" ] } }, status: :unprocessable_entity
+          return
+        end
+
+        @thought.parent = parent
+      end
 
       if @thought.save
         render json: { thought: thought_json(@thought) }, status: :created
@@ -70,12 +88,14 @@ module Api
       params.require(:thought).permit(:content, tags: [])
     end
 
-    def thought_json(thought)
+    def thought_json(thought, include_replies: false)
       json = {
         id: thought.public_id,
         content: thought.content,
         tags: thought.tags,
         source: thought.source,
+        parent_id: thought.parent&.public_id,
+        reply_count: thought.reply_count,
         created_at: thought.created_at.iso8601
       }
 
@@ -96,6 +116,10 @@ module Api
           description: first["description"],
           image: first["image"]
         }
+      end
+
+      if include_replies
+        json[:replies] = thought.replies.map { |reply| thought_json(reply, include_replies: true) }
       end
 
       json

--- a/app/controllers/thoughts_controller.rb
+++ b/app/controllers/thoughts_controller.rb
@@ -1,6 +1,6 @@
 class ThoughtsController < ApplicationController
   def index
-    @thoughts = Thought.recent.page(params[:page]).per(25)
+    @thoughts = Thought.top_level.recent.page(params[:page]).per(25)
 
     if params[:tag].present?
       @thoughts = @thoughts.with_tag(params[:tag])

--- a/app/models/thought.rb
+++ b/app/models/thought.rb
@@ -3,10 +3,15 @@ class Thought < ApplicationRecord
 
   SOURCES = %w[web cli iphone].freeze
 
+  belongs_to :parent, class_name: "Thought", optional: true
+  has_many :replies, -> { order(created_at: :asc) },
+           class_name: "Thought", foreign_key: :parent_id, inverse_of: :parent, dependent: :destroy
+
   validates :content, presence: true, length: { maximum: MAX_CONTENT_LENGTH }
   validates :source, inclusion: { in: SOURCES }
   validates :view_count, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validates :public_id, presence: true, uniqueness: true
+  validate :no_circular_parentage
 
   before_validation :generate_public_id, on: :create
   before_save :normalize_tags
@@ -20,6 +25,25 @@ class Thought < ApplicationRecord
   scope :recent, -> { order(created_at: :desc) }
   scope :with_tag, ->(tag) { where("? = ANY(tags)", tag) }
   scope :search, ->(query) { where("content ILIKE ?", "%#{query}%") }
+  scope :top_level, -> { where(parent_id: nil) }
+
+  def reply_count
+    replies.count
+  end
+
+  # Walk up the parent chain to the topmost ancestor
+  def thread_root
+    node = self
+    seen = [ id ].compact
+    while node.parent_id.present?
+      parent = node.parent
+      break if parent.nil? || seen.include?(parent.id)
+
+      seen << parent.id
+      node = parent
+    end
+    node
+  end
 
   def increment_view_count!
     increment!(:view_count)
@@ -35,6 +59,27 @@ class Thought < ApplicationRecord
   end
 
   private
+
+  def no_circular_parentage
+    return if parent_id.blank?
+
+    if parent_id == id
+      errors.add(:parent_id, "can't be itself")
+      return
+    end
+
+    ancestor = parent
+    seen = []
+    while ancestor
+      if ancestor.id == id || seen.include?(ancestor.id)
+        errors.add(:parent_id, "can't create a circular thread")
+        return
+      end
+
+      seen << ancestor.id
+      ancestor = ancestor.parent
+    end
+  end
 
   def generate_public_id
     self.public_id ||= SecureRandom.alphanumeric(12)

--- a/app/views/admin/thoughts/_form.html.erb
+++ b/app/views/admin/thoughts/_form.html.erb
@@ -10,6 +10,11 @@
     </div>
   <% end %>
 
+  <% if thought.parent.present? %>
+    <%= render "parent_context", parent: thought.parent %>
+    <%= f.hidden_field :parent_id %>
+  <% end %>
+
   <div data-controller="character-counter">
     <%= f.label :content, class: "block text-sm font-medium text-gray-700" %>
     <div class="mt-1">

--- a/app/views/admin/thoughts/_parent_context.html.erb
+++ b/app/views/admin/thoughts/_parent_context.html.erb
@@ -1,0 +1,4 @@
+<div class="rounded-md border-l-4 border-gray-300 bg-gray-50 px-4 py-3">
+  <p class="text-xs font-medium text-gray-500">Replying to:</p>
+  <p class="mt-1 text-sm text-gray-700"><%= truncate(parent.content, length: 100) %></p>
+</div>

--- a/app/views/admin/thoughts/index.html.erb
+++ b/app/views/admin/thoughts/index.html.erb
@@ -37,6 +37,11 @@
           </td>
           <td class="px-6 py-4 text-right text-sm font-medium">
             <div class="flex items-center justify-end gap-2">
+              <%= link_to new_admin_thought_path(parent_id: thought.public_id), class: "p-2 text-gray-500 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors", title: "Reply" do %>
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6"></path>
+                </svg>
+              <% end %>
               <%= link_to edit_admin_thought_path(thought), class: "p-2 text-blue-600 hover:text-blue-900 hover:bg-blue-50 rounded-lg transition-colors", title: "Edit" do %>
                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path>

--- a/app/views/admin/thoughts/show.html.erb
+++ b/app/views/admin/thoughts/show.html.erb
@@ -2,10 +2,17 @@
   <div class="mb-6 flex justify-between items-center">
     <h1 class="text-2xl font-bold text-gray-900">Thought Details</h1>
     <div class="space-x-2">
+      <%= link_to "Reply", new_admin_thought_path(parent_id: @thought.public_id), class: "px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50" %>
       <%= link_to "Edit", edit_admin_thought_path(@thought), class: "px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50" %>
       <%= link_to "Back", admin_thoughts_path, class: "px-4 py-2 text-sm font-medium text-gray-500 hover:text-gray-700" %>
     </div>
   </div>
+
+  <% if @thought.parent.present? %>
+    <div class="mb-4">
+      <%= render "parent_context", parent: @thought.parent %>
+    </div>
+  <% end %>
 
   <div class="bg-white shadow rounded-lg overflow-hidden">
     <div class="p-6">

--- a/app/views/shared/_thought_card.html.erb
+++ b/app/views/shared/_thought_card.html.erb
@@ -79,6 +79,18 @@
           <% end %>
         </div>
       <% end %>
+
+      <% reply_count = thought.reply_count %>
+      <% if reply_count > 0 %>
+        <%# The whole card is already a link to thought_path, so this stays a span: %>
+        <%# a nested anchor would be invalid HTML and break the card layout. %>
+        <div class="mt-2 flex items-center gap-1.5 text-xs text-zinc-500 dark:text-zinc-400 group-hover:text-zinc-700 dark:group-hover:text-zinc-200 transition-colors">
+          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 20 20" fill="currentColor" class="pointer-events-none">
+            <path fill-rule="evenodd" d="M10 2c-4.418 0-8 2.985-8 6.667 0 2.05 1.11 3.884 2.855 5.098a.75.75 0 0 1 .317.71l-.24 1.797 1.9-1.03a.75.75 0 0 1 .53-.07c.83.19 1.71.162 2.638.162 4.418 0 8-2.985 8-6.667C18 4.985 14.418 2 10 2Z" clip-rule="evenodd" />
+          </svg>
+          <span><%= pluralize(reply_count, "reply") %></span>
+        </div>
+      <% end %>
     </div>
   <% end %>
 </article>

--- a/app/views/thoughts/_reply.html.erb
+++ b/app/views/thoughts/_reply.html.erb
@@ -1,0 +1,47 @@
+<%# Visual indentation is capped: once depth hits 3 the child depth stops %>
+<%# growing, so deeper replies render flush with the level-3 indent. %>
+<% child_depth = [ depth + 1, 3 ].min %>
+
+<div class="reply">
+  <article class="flex gap-3 py-3">
+    <div class="shrink-0">
+      <%= image_tag "https://swm.cc/profile.svg",
+          class: "w-8 h-8 rounded-full bg-white dark:bg-zinc-900",
+          alt: "swmcc" %>
+    </div>
+
+    <div class="flex-1 min-w-0">
+      <div class="flex items-center gap-1">
+        <span class="text-sm font-semibold text-zinc-900 dark:text-white">swmcc</span>
+        <span class="text-xs text-zinc-400 dark:text-zinc-600">·</span>
+        <span data-tooltip="<%= reply.source_label %>" aria-label="<%= reply.source_label %>" class="tooltip text-zinc-400 dark:text-zinc-500 cursor-help inline-flex">
+          <%= render partial: "shared/source_icon", locals: { source: reply.source } %>
+        </span>
+        <span class="text-xs text-zinc-400 dark:text-zinc-600">·</span>
+        <%= link_to thought_path(reply), class: "text-xs text-zinc-500 dark:text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors" do %>
+          <time datetime="<%= reply.created_at.iso8601 %>">
+            <%= full_timestamp(reply.created_at) %>
+          </time>
+        <% end %>
+      </div>
+
+      <p class="mt-1 text-[15px] text-zinc-800 dark:text-zinc-200 leading-relaxed">
+        <%= reply.content %>
+      </p>
+
+      <% if reply.tags.any? %>
+        <div class="mt-2 text-sm">
+          <% reply.tags.each_with_index do |tag, i| %>
+            <%= link_to "##{tag}", root_path(tag: tag), class: "text-blue-500 dark:text-blue-400 hover:underline" %><% if i < reply.tags.length - 1 %> <% end %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </article>
+
+  <% if reply.replies.any? %>
+    <div class="<%= "pl-6 border-l border-zinc-200 dark:border-zinc-800" if child_depth > depth %>">
+      <%= render partial: "thoughts/reply", collection: reply.replies, as: :reply, locals: { depth: child_depth } %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/thoughts/show.html.erb
+++ b/app/views/thoughts/show.html.erb
@@ -113,6 +113,18 @@
     </div>
   </article>
 
+  <% replies = @thought.replies %>
+  <% if replies.any? %>
+    <section class="mt-10">
+      <h2 class="text-xs font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-2">
+        <%= pluralize(replies.size, "reply") %>
+      </h2>
+      <div class="pl-6 border-l border-zinc-200 dark:border-zinc-800">
+        <%= render partial: "thoughts/reply", collection: replies, as: :reply, locals: { depth: 0 } %>
+      </div>
+    </section>
+  <% end %>
+
   <!-- Share section -->
   <div class="mt-12 text-center">
     <p class="text-xs font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-4">Share this thought</p>

--- a/bin/thought
+++ b/bin/thought
@@ -34,17 +34,21 @@ Usage: thought [OPTIONS] [CONTENT]
 Post a thought from the command line.
 
 Options:
-  -t, --tag TAG    Add a tag (can be used multiple times)
-  -h, --help       Show this help message
-  -v, --version    Show version
-  --init           Initialize configuration
-  --config         Show current configuration
+  -t, --tag TAG      Add a tag (can be used multiple times)
+  -r, --reply ID     Reply to a thought (use parent's public_id)
+  -h, --help         Show this help message
+  -v, --version      Show version
+  --init             Initialize configuration
+  --config           Show current configuration
 
 Examples:
   thought "Hello world"
   thought -t coding -t ruby "Learning Ruby today"
   thought --tag=work "Finished the feature"
+  thought -r abc123XYZ456 "Replying to that"
+  thought --reply=abc123XYZ456 -t coding "Tagged reply"
   echo "Piped thought" | thought
+  echo "Piped reply" | thought -r abc123XYZ456
   echo "With tags" | thought -t idea
 
 Configuration:
@@ -154,12 +158,20 @@ post_thought() {
         tags_json=$(printf '%s\n' "${tags[@]}" | jq -R . | jq -s .)
     fi
 
-    # Build request body
+    # Build request body (conditionally include parent_id)
     local body
-    body=$(jq -n \
-        --arg content "$content" \
-        --argjson tags "$tags_json" \
-        '{thought: {content: $content, tags: $tags}}')
+    if [[ -n "${PARENT_ID}" ]]; then
+        body=$(jq -n \
+            --arg content "$content" \
+            --argjson tags "$tags_json" \
+            --arg parent_id "$PARENT_ID" \
+            '{thought: {content: $content, tags: $tags, parent_id: $parent_id}}')
+    else
+        body=$(jq -n \
+            --arg content "$content" \
+            --argjson tags "$tags_json" \
+            '{thought: {content: $content, tags: $tags}}')
+    fi
 
     # Make API request
     local response
@@ -178,8 +190,15 @@ post_thought() {
     if [[ "$http_code" == "201" ]]; then
         local id
         id=$(echo "$response" | jq -r '.thought.id')
+        local parent_id
+        parent_id=$(echo "$response" | jq -r '.thought.parent_id // empty')
+
         echo -e "${GREEN}Thought posted successfully.${NC}"
         echo -e "ID: ${BLUE}${id}${NC}"
+
+        if [[ -n "${parent_id}" ]]; then
+            echo -e "In reply to: ${BLUE}${parent_id}${NC}"
+        fi
 
         if [[ ${#tags[@]} -gt 0 ]]; then
             echo -e "Tags: ${YELLOW}${tags[*]}${NC}"
@@ -194,6 +213,7 @@ post_thought() {
 # Parse arguments
 TAGS=()
 CONTENT=""
+PARENT_ID=""
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -227,6 +247,19 @@ while [[ $# -gt 0 ]]; do
         --tag=*)
             IFS=',' read -ra SPLIT_TAGS <<< "${1#*=}"
             TAGS+=("${SPLIT_TAGS[@]}")
+            shift
+            ;;
+        -r|--reply)
+            if [[ -n "$2" && ! "$2" =~ ^- ]]; then
+                PARENT_ID="$2"
+                shift 2
+            else
+                echo -e "${RED}Error: --reply requires an argument.${NC}" >&2
+                exit 1
+            fi
+            ;;
+        --reply=*)
+            PARENT_ID="${1#*=}"
             shift
             ;;
         -*)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,9 @@ Rails.application.routes.draw do
 
   # JSON API (read = public, write = token auth)
   namespace :api do
-    resources :thoughts, only: [ :index, :show, :create, :update, :destroy ]
+    resources :thoughts, only: [ :index, :show, :create, :update, :destroy ] do
+      member { get :thread }
+    end
     get "tags", to: "tags#index"
   end
 

--- a/db/migrate/20260805180638_add_parent_to_thoughts.rb
+++ b/db/migrate/20260805180638_add_parent_to_thoughts.rb
@@ -1,0 +1,5 @@
+class AddParentToThoughts < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :thoughts, :parent, null: true, index: true, foreign_key: { to_table: :thoughts }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_07_161936) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_05_180638) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -32,13 +32,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_07_161936) do
     t.jsonb "link_previews", default: []
     t.string "link_title"
     t.string "link_url"
+    t.bigint "parent_id"
     t.string "public_id", null: false
     t.string "source", default: "web", null: false
     t.string "tags", default: [], array: true
     t.datetime "updated_at", null: false
     t.integer "view_count", default: 0
     t.index ["created_at"], name: "index_thoughts_on_created_at"
+    t.index ["parent_id"], name: "index_thoughts_on_parent_id"
     t.index ["public_id"], name: "index_thoughts_on_public_id", unique: true
     t.index ["tags"], name: "index_thoughts_on_tags", using: :gin
   end
+
+  add_foreign_key "thoughts", "thoughts", column: "parent_id"
 end

--- a/spec/models/thought_spec.rb
+++ b/spec/models/thought_spec.rb
@@ -125,4 +125,106 @@ RSpec.describe Thought, type: :model do
       expect(thought.source_label).to eq("Written from iPhone")
     end
   end
+
+  describe "threading" do
+    it "defaults parent_id to nil" do
+      thought = create(:thought, content: "A top level thought")
+      expect(thought.parent_id).to be_nil
+      expect(thought.parent).to be_nil
+    end
+
+    it "links a reply to its parent and back again" do
+      parent = create(:thought, content: "Parent thought")
+      reply = create(:thought, content: "Reply thought", parent: parent)
+
+      expect(reply.parent).to eq(parent)
+      expect(parent.replies).to include(reply)
+    end
+
+    it "orders replies oldest first" do
+      parent = create(:thought, content: "Parent thought")
+      newer = create(:thought, content: "Newer reply", parent: parent, created_at: 1.hour.ago)
+      older = create(:thought, content: "Older reply", parent: parent, created_at: 1.day.ago)
+
+      expect(parent.replies.to_a).to eq([ older, newer ])
+    end
+
+    describe ".top_level" do
+      it "returns only thoughts without a parent" do
+        parent = create(:thought, content: "Parent thought")
+        create(:thought, content: "Reply thought", parent: parent)
+
+        expect(Thought.top_level).to contain_exactly(parent)
+      end
+    end
+
+    describe "#reply_count" do
+      it "counts direct replies only" do
+        parent = create(:thought, content: "Parent thought")
+        reply = create(:thought, content: "First reply", parent: parent)
+        create(:thought, content: "Second reply", parent: parent)
+        create(:thought, content: "Nested reply", parent: reply)
+
+        expect(parent.reply_count).to eq(2)
+        expect(reply.reply_count).to eq(1)
+      end
+
+      it "is zero for a thought with no replies" do
+        expect(create(:thought, content: "Lonely thought").reply_count).to eq(0)
+      end
+    end
+
+    describe "#thread_root" do
+      it "returns self for a top-level thought" do
+        thought = create(:thought, content: "Top level thought")
+        expect(thought.thread_root).to eq(thought)
+      end
+
+      it "returns the topmost ancestor from a nested reply" do
+        root = create(:thought, content: "Root thought")
+        reply = create(:thought, content: "Reply thought", parent: root)
+        nested = create(:thought, content: "Nested reply", parent: reply)
+
+        expect(nested.thread_root).to eq(root)
+      end
+    end
+
+    describe "circular parentage" do
+      it "rejects a thought that is its own parent" do
+        thought = create(:thought, content: "Self referencing thought")
+        thought.parent_id = thought.id
+
+        expect(thought).not_to be_valid
+        expect(thought.errors[:parent_id]).to include("can't be itself")
+      end
+
+      it "rejects a cycle between two thoughts" do
+        a = create(:thought, content: "Thought A")
+        b = create(:thought, content: "Thought B", parent: a)
+
+        a.parent = b
+
+        expect(a).not_to be_valid
+        expect(a.errors[:parent_id]).to include("can't create a circular thread")
+      end
+
+      it "allows a legitimate nested chain" do
+        root = create(:thought, content: "Root thought")
+        reply = create(:thought, content: "Reply thought", parent: root)
+        nested = build(:thought, content: "Nested reply", parent: reply)
+
+        expect(nested).to be_valid
+      end
+    end
+
+    describe "dependent destroy" do
+      it "destroys replies when the parent is destroyed" do
+        parent = create(:thought, content: "Parent thought")
+        reply = create(:thought, content: "Reply thought", parent: parent)
+        create(:thought, content: "Nested reply", parent: reply)
+
+        expect { parent.destroy }.to change(Thought, :count).by(-3)
+      end
+    end
+  end
 end

--- a/spec/requests/admin/thoughts_spec.rb
+++ b/spec/requests/admin/thoughts_spec.rb
@@ -43,6 +43,17 @@ RSpec.describe "Admin::Thoughts", type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("New Thought")
     end
+
+    it "renders the parent context when parent_id is present" do
+      parent = create(:thought, content: "The original thought")
+
+      get new_admin_thought_path(parent_id: parent.public_id)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Replying to:")
+      expect(response.body).to include("The original thought")
+      expect(response.body).to include(%(name="thought[parent_id]"))
+    end
   end
 
   describe "POST /admin/thoughts" do
@@ -53,6 +64,17 @@ RSpec.describe "Admin::Thoughts", type: :request do
         }.to change(Thought, :count).by(1)
 
         expect(response).to redirect_to(admin_thoughts_path)
+      end
+
+      it "creates a reply when parent_id is present" do
+        parent = create(:thought, content: "The original thought")
+
+        expect {
+          post admin_thoughts_path, params: { thought: { content: "A considered reply", parent_id: parent.id } }
+        }.to change(Thought, :count).by(1)
+
+        expect(response).to redirect_to(admin_thoughts_path)
+        expect(Thought.last.parent).to eq(parent)
       end
     end
 

--- a/spec/requests/api/thoughts_spec.rb
+++ b/spec/requests/api/thoughts_spec.rb
@@ -243,6 +243,108 @@ RSpec.describe "Api::Thoughts", type: :request do
     end
   end
 
+  describe "threaded replies" do
+    describe "GET /api/thoughts" do
+      it "excludes replies and reports the reply count" do
+        parent = create(:thought, content: "Parent thought")
+        create(:thought, content: "Reply thought", parent: parent)
+
+        get api_thoughts_path
+
+        json = JSON.parse(response.body)
+        expect(json["thoughts"].length).to eq(1)
+        expect(json["thoughts"].first["id"]).to eq(parent.public_id)
+        expect(json["thoughts"].first["reply_count"]).to eq(1)
+        expect(json["thoughts"].first["parent_id"]).to be_nil
+        expect(json["thoughts"].first).not_to have_key("replies")
+      end
+    end
+
+    describe "GET /api/thoughts/:id" do
+      it "includes nested replies and the reply count" do
+        parent = create(:thought, content: "Parent thought")
+        reply = create(:thought, content: "Reply thought", parent: parent)
+        create(:thought, content: "Nested reply", parent: reply)
+
+        get api_thought_path(parent)
+
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)["thought"]
+        expect(json["reply_count"]).to eq(1)
+        expect(json["replies"].length).to eq(1)
+        expect(json["replies"].first["id"]).to eq(reply.public_id)
+        expect(json["replies"].first["parent_id"]).to eq(parent.public_id)
+        expect(json["replies"].first["replies"].first["content"]).to eq("Nested reply")
+      end
+    end
+
+    describe "GET /api/thoughts/:id/thread" do
+      it "returns the root with fully nested replies from a leaf reply" do
+        root = create(:thought, content: "Root thought")
+        reply = create(:thought, content: "Reply thought", parent: root)
+        leaf = create(:thought, content: "Leaf reply", parent: reply)
+
+        get thread_api_thought_path(leaf)
+
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)["thought"]
+        expect(json["id"]).to eq(root.public_id)
+        expect(json["replies"].first["id"]).to eq(reply.public_id)
+        expect(json["replies"].first["replies"].first["id"]).to eq(leaf.public_id)
+      end
+
+      it "does not increment view counts" do
+        root = create(:thought, content: "Root thought", view_count: 0)
+
+        expect {
+          get thread_api_thought_path(root)
+        }.not_to change { root.reload.view_count }
+      end
+
+      it "returns 404 for a non-existent thought" do
+        get thread_api_thought_path(id: "nonexistent123")
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    describe "POST /api/thoughts" do
+      let(:parent) { create(:thought, content: "Parent thought") }
+
+      it "creates a reply for a valid parent public_id" do
+        params = { thought: { content: "A reply", parent_id: parent.public_id } }
+
+        expect {
+          post api_thoughts_path, params: params, headers: auth_headers
+        }.to change(Thought, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        json = JSON.parse(response.body)["thought"]
+        expect(json["parent_id"]).to eq(parent.public_id)
+        expect(Thought.find_by(public_id: json["id"]).parent).to eq(parent)
+      end
+
+      it "returns 422 when the parent does not exist" do
+        params = { thought: { content: "A reply", parent_id: "nonexistent123" } }
+
+        expect {
+          post api_thoughts_path, params: params, headers: auth_headers
+        }.not_to change(Thought, :count)
+
+        expect(response).to have_http_status(:unprocessable_content)
+        json = JSON.parse(response.body)
+        expect(json["errors"]["parent_id"]).to include("does not exist")
+      end
+
+      it "requires authentication" do
+        params = { thought: { content: "A reply", parent_id: parent.public_id } }
+
+        post api_thoughts_path, params: params
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
   describe "GET /api/tags" do
     it "returns all unique tags" do
       create(:thought, tags: [ "rails", "ruby" ])

--- a/spec/requests/thoughts_spec.rb
+++ b/spec/requests/thoughts_spec.rb
@@ -52,6 +52,25 @@ RSpec.describe "Thoughts", type: :request do
       expect(response.body).to include(matching.content)
       expect(response.body).not_to include(non_matching.content)
     end
+
+    it "shows only top-level thoughts" do
+      parent = create(:thought, content: "Parent thought")
+      reply = create(:thought, content: "A threaded reply", parent: parent)
+
+      get root_path
+
+      expect(response.body).to include(parent.content)
+      expect(response.body).not_to include(reply.content)
+    end
+
+    it "shows a reply count indicator for thoughts with replies" do
+      parent = create(:thought, content: "Parent thought")
+      create_list(:thought, 2, content: "A threaded reply", parent: parent)
+
+      get root_path
+
+      expect(response.body).to include("2 replies")
+    end
   end
 
   describe "GET /thoughts/:id" do
@@ -76,6 +95,18 @@ RSpec.describe "Thoughts", type: :request do
       thought.tags.each do |tag|
         expect(response.body).to include("##{tag}")
       end
+    end
+
+    it "displays the thread of replies" do
+      parent = create(:thought, content: "Parent thought")
+      reply = create(:thought, content: "A threaded reply", parent: parent)
+      create(:thought, content: "A nested reply", parent: reply)
+
+      get thought_path(parent)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("A threaded reply")
+      expect(response.body).to include("A nested reply")
     end
   end
 end

--- a/spec/system/admin_thoughts_spec.rb
+++ b/spec/system/admin_thoughts_spec.rb
@@ -48,6 +48,24 @@ RSpec.describe "Admin Thoughts Management", type: :system do
     end
   end
 
+  describe "replying to a thought" do
+    let!(:parent) { create(:thought, content: "The original thought") }
+
+    it "creates a reply from the index page" do
+      visit admin_thoughts_path
+      click_link "Reply"
+
+      expect(page).to have_content("Replying to:")
+      expect(page).to have_content("The original thought")
+
+      fill_in "Content", with: "A considered reply"
+      click_button "Create Thought"
+
+      expect(page).to have_content("Thought was successfully created")
+      expect(Thought.find_by(content: "A considered reply").parent).to eq(parent)
+    end
+  end
+
   describe "editing a thought" do
     let!(:thought) { create(:thought, content: "Original content") }
 

--- a/spec/system/public_timeline_spec.rb
+++ b/spec/system/public_timeline_spec.rb
@@ -127,4 +127,51 @@ RSpec.describe "Public Timeline", type: :system do
       expect(thought.reload.view_count).to eq(6)
     end
   end
+
+  describe "threaded replies" do
+    it "shows a reply count indicator instead of the replies themselves" do
+      parent = create(:thought, content: "Parent thought")
+      create(:thought, content: "First reply", parent: parent)
+      create(:thought, content: "Second reply", parent: parent)
+
+      visit root_path
+
+      expect(page).to have_content("Parent thought")
+      expect(page).to have_content("2 replies")
+      expect(page).not_to have_content("First reply")
+    end
+
+    it "pluralises a single reply" do
+      parent = create(:thought, content: "Parent thought")
+      create(:thought, content: "Only reply", parent: parent)
+
+      visit root_path
+
+      expect(page).to have_content("1 reply")
+    end
+
+    it "renders nested replies under the parent on the show page" do
+      parent = create(:thought, content: "Parent thought")
+      reply = create(:thought, content: "First reply", parent: parent)
+      create(:thought, content: "Nested reply", parent: reply)
+
+      visit thought_path(parent)
+
+      expect(page).to have_content("Parent thought")
+      expect(page).to have_content("First reply")
+      expect(page).to have_content("Nested reply")
+
+      # The nested reply renders inside its parent reply, not alongside it.
+      expect(page).to have_css(".reply .reply")
+    end
+
+    it "links a reply to its own page" do
+      parent = create(:thought, content: "Parent thought")
+      reply = create(:thought, content: "First reply", parent: parent)
+
+      visit thought_path(parent)
+
+      expect(page).to have_link(href: thought_path(reply))
+    end
+  end
 end


### PR DESCRIPTION
Closes #27.

## Summary
- Adds self-referential threading to `Thought`: nullable `parent_id` (FK + index), `parent`/`replies` associations with `dependent: :destroy`, cycle-prevention validation, `top_level` scope, `reply_count`, and `thread_root`
- **Web**: thought show page renders replies nested beneath the thought (oldest first, indentation capped at 3 levels); timeline shows top-level thoughts only with a reply-count indicator; admin gains a Reply action with parent context shown on the form/edit views
- **API**: `POST /api/thoughts` accepts optional `parent_id` (parent's `public_id`, 422 if unknown); thought JSON gains `parent_id`, `reply_count`, and recursively nested `replies`; index returns top-level only; new `GET /api/thoughts/:id/thread` returns the thread root with fully nested replies
- **CLI**: `thought -r <public_id> "..."` / `--reply` posts a reply (works with tags and piped stdin) and prints the new id plus its parent for chaining
- README updated (API + CLI sections)

## Test plan
- [x] `bundle exec rspec` — model specs (associations, cycle guard, destroy cascade), API request specs (reply create, 422 on missing parent, thread endpoint, index excludes replies), admin/public request specs, system specs (threaded show page, timeline indicator, admin reply flow)
- [x] `bundle exec rubocop`
- [x] `bundle exec brakeman -q --no-pager`
- [ ] Manual: post a reply via `bin/thought -r <id>`, confirm it renders nested on the thought page and the timeline shows the reply count

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #27

⚔ orchestrated by thrawn