### PR TITLE
🖼️ Handle dead link-preview images gracefully (render + extraction)

### DIFF
--- a/app/javascript/controllers/link_preview_controller.js
+++ b/app/javascript/controllers/link_preview_controller.js
@@ -1,0 +1,20 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Removes a link preview's image block when the remote og:image fails to
+// load — dead hotlinks otherwise render as broken picture boxes. The card
+// gracefully collapses to its text-only variant.
+export default class extends Controller {
+  static targets = [ "image" ]
+
+  imageTargetConnected(img) {
+    if (img.complete && img.naturalWidth === 0) {
+      this.remove(img)
+    } else {
+      img.addEventListener("error", () => this.remove(img), { once: true })
+    }
+  }
+
+  remove(img) {
+    img.closest("[data-link-preview-image-box]")?.remove()
+  }
+}

--- a/app/models/thought.rb
+++ b/app/models/thought.rb
@@ -120,17 +120,35 @@ class Thought < ApplicationRecord
       { "url" => url, "title" => nil, "description" => nil, "image" => url }
     else
       og = OpenGraphReader.fetch(url)
-      if og&.og&.title.present? || og&.og&.image&.url.present?
+      return nil unless og
+
+      title = og.og.title
+      image = og.og.image&.url
+      # og:images rot (or lie) — only store one that actually serves an image
+      image = nil unless fetchable_image?(image)
+      if title.present? || image.present?
         {
           "url" => url,
-          "title" => og.og.title&.truncate(100),
+          "title" => title&.truncate(100),
           "description" => og.og.description&.truncate(200),
-          "image" => og.og.image&.url
+          "image" => image
         }
       end
     end
   rescue StandardError
     nil
+  end
+
+  def fetchable_image?(url)
+    return false if url.blank?
+
+    uri = URI.parse(follow_redirects(url))
+    response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https", open_timeout: 5, read_timeout: 5) do |http|
+      http.head(uri.request_uri)
+    end
+    response.is_a?(Net::HTTPSuccess) && response["content-type"].to_s.start_with?("image/")
+  rescue StandardError
+    false
   end
 
   def follow_redirects(url, limit = 5)

--- a/app/views/shared/_thought_card.html.erb
+++ b/app/views/shared/_thought_card.html.erb
@@ -29,10 +29,10 @@
       <% if previews.any? %>
         <% if previews.size == 1 %>
           <% preview = previews.first %>
-          <div class="mt-3 rounded-xl border border-zinc-200 dark:border-zinc-700 overflow-hidden hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors">
+          <div class="mt-3 rounded-xl border border-zinc-200 dark:border-zinc-700 overflow-hidden hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors" data-controller="link-preview">
             <% if preview["image"].present? %>
-              <div class="aspect-[2/1] bg-zinc-100 dark:bg-zinc-800">
-                <%= image_tag preview["image"], class: "w-full h-full object-cover", alt: preview["title"] %>
+              <div class="aspect-[2/1] bg-zinc-100 dark:bg-zinc-800" data-link-preview-image-box>
+                <%= image_tag preview["image"], class: "w-full h-full object-cover", alt: preview["title"], data: { link_preview_target: "image" } %>
               </div>
             <% end %>
             <div class="p-3">
@@ -48,10 +48,10 @@
         <% else %>
           <div class="mt-3 grid grid-cols-2 gap-2">
             <% previews.each do |preview| %>
-              <a href="<%= preview["url"] %>" target="_blank" rel="noopener" onclick="event.stopPropagation();" class="block rounded-lg border border-zinc-200 dark:border-zinc-700 overflow-hidden hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors">
+              <a href="<%= preview["url"] %>" target="_blank" rel="noopener" onclick="event.stopPropagation();" class="block rounded-lg border border-zinc-200 dark:border-zinc-700 overflow-hidden hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors" data-controller="link-preview">
                 <% if preview["image"].present? %>
-                  <div class="aspect-square bg-zinc-100 dark:bg-zinc-800">
-                    <%= image_tag preview["image"], class: "w-full h-full object-cover", alt: preview["title"] %>
+                  <div class="aspect-square bg-zinc-100 dark:bg-zinc-800" data-link-preview-image-box>
+                    <%= image_tag preview["image"], class: "w-full h-full object-cover", alt: preview["title"], data: { link_preview_target: "image" } %>
                   </div>
                 <% else %>
                   <div class="aspect-square bg-zinc-100 dark:bg-zinc-800 flex items-center justify-center">

--- a/app/views/thoughts/show.html.erb
+++ b/app/views/thoughts/show.html.erb
@@ -58,10 +58,10 @@
       <% if previews.any? %>
         <% if previews.size == 1 %>
           <% preview = previews.first %>
-          <a href="<%= preview["url"] %>" target="_blank" rel="noopener" class="block mt-4 rounded-xl border border-zinc-200 dark:border-zinc-700 overflow-hidden hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors">
+          <a href="<%= preview["url"] %>" target="_blank" rel="noopener" class="block mt-4 rounded-xl border border-zinc-200 dark:border-zinc-700 overflow-hidden hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors" data-controller="link-preview">
             <% if preview["image"].present? %>
-              <div class="aspect-[2/1] bg-zinc-100 dark:bg-zinc-800">
-                <%= image_tag preview["image"], class: "w-full h-full object-cover", alt: preview["title"] %>
+              <div class="aspect-[2/1] bg-zinc-100 dark:bg-zinc-800" data-link-preview-image-box>
+                <%= image_tag preview["image"], class: "w-full h-full object-cover", alt: preview["title"], data: { link_preview_target: "image" } %>
               </div>
             <% end %>
             <div class="p-4">

--- a/spec/models/thought_link_preview_spec.rb
+++ b/spec/models/thought_link_preview_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+RSpec.describe Thought, "#link previews" do
+  def og_double(title:, image_url:)
+    image = image_url && double("og image", url: image_url)
+    og = double("og", title: title, description: "A description", image: image)
+    double("OpenGraphReader result", og: og)
+  end
+
+  def stub_head_response(success:, content_type: "image/png")
+    response = success ? Net::HTTPSuccess.new("1.1", "200", "OK") : Net::HTTPNotFound.new("1.1", "404", "Not Found")
+    allow(response).to receive(:[]).with("content-type").and_return(content_type)
+    allow(response).to receive(:[]).with("location").and_return(nil)
+    allow(Net::HTTP).to receive(:start).and_return(response)
+    response
+  end
+
+  describe "og:image validation" do
+    it "stores the image when it serves an image content type" do
+      stub_head_response(success: true)
+      allow(OpenGraphReader).to receive(:fetch)
+        .and_return(og_double(title: "A page", image_url: "https://example.com/og.png"))
+
+      thought = create(:thought, content: "look at https://example.com/page")
+
+      expect(thought.link_previews.first["image"]).to eq("https://example.com/og.png")
+    end
+
+    it "drops the image but keeps the preview when the og:image 404s" do
+      stub_head_response(success: false, content_type: "text/html")
+      allow(OpenGraphReader).to receive(:fetch)
+        .and_return(og_double(title: "A page", image_url: "https://example.com/dead.png"))
+
+      thought = create(:thought, content: "look at https://example.com/page")
+
+      expect(thought.link_previews.first["title"]).to eq("A page")
+      expect(thought.link_previews.first["image"]).to be_nil
+    end
+
+    it "drops the image when the URL serves a non-image content type" do
+      stub_head_response(success: true, content_type: "text/html; charset=utf-8")
+      allow(OpenGraphReader).to receive(:fetch)
+        .and_return(og_double(title: "A page", image_url: "https://example.com/error-page"))
+
+      thought = create(:thought, content: "look at https://example.com/page")
+
+      expect(thought.link_previews.first["image"]).to be_nil
+    end
+
+    it "stores no preview when there is no title and the image is dead" do
+      stub_head_response(success: false, content_type: "text/html")
+      allow(OpenGraphReader).to receive(:fetch)
+        .and_return(og_double(title: nil, image_url: "https://example.com/dead.png"))
+
+      thought = create(:thought, content: "look at https://example.com/page")
+
+      expect(thought.link_previews).to be_empty
+    end
+
+    it "treats a network error while validating as a dead image" do
+      allow(Net::HTTP).to receive(:start).and_raise(Errno::ECONNREFUSED)
+      allow(OpenGraphReader).to receive(:fetch)
+        .and_return(og_double(title: "A page", image_url: "https://example.com/og.png"))
+
+      thought = create(:thought, content: "look at https://example.com/page")
+
+      expect(thought.link_previews.first["image"]).to be_nil
+      expect(thought.link_previews.first["title"]).to eq("A page")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- **Render**: new `link-preview` Stimulus controller removes a preview's image box when the remote og:image fails to load — the card collapses to its text-only variant instead of showing a broken picture box. Wired into both timeline card variants and the thought show page. Handles images that errored before Stimulus connected (`complete && naturalWidth === 0`).
- **Extraction**: og:image URLs are now HEAD-validated (must answer 2xx with `image/*`) before being stored in `link_previews`; a dead image is dropped while keeping title/description, and a preview with neither title nor live image isn't stored at all.
- Existing swm.cc previews on production will self-heal at render time via the JS path; the extraction fix prevents new rot. Root cause of the current breakage is swmcc/swmcc.github.io#106 (their og:image 404s).

Closes #38

## Test plan
- [x] 5 new model specs covering: live image stored, 404 image dropped (title kept), non-image content-type dropped, no-title+dead-image stores nothing, network error treated as dead
- [x] Full suite 153/153 · rubocop clean · brakeman exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)