### PR TITLE
⬆️ Bump brakeman to 8.0.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.24.6)
       msgpack (~> 1.2)
-    brakeman (8.0.5)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     bundler-audit (0.9.3)


### PR DESCRIPTION
`bin/brakeman` injects `--ensure-latest`, so CI's `scan_ruby` job exits 5 whenever the pinned brakeman is not the newest published gem. The lockfile pinned 8.0.5 while 8.0.6 is current, which was failing every open PR (#41, #42, #43).

Bumps brakeman 8.0.5 → 8.0.6. Scan is clean (0 warnings).